### PR TITLE
Remove overriden createJSModules RN 0.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 Integrates [Google App Indexing](https://firebase.google.com/docs/app-indexing/) with React Native.
+Support for react native 0.47
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 
 Integrates [Google App Indexing](https://firebase.google.com/docs/app-indexing/) with React Native.
-Support for react native 0.47
 
 
 ## Installation

--- a/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
+++ b/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
@@ -28,6 +28,11 @@ public class AppIndexingPackage implements ReactPackage {
         return modules;
     }
 
+    // Deprecated RN 0.47
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+    
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();

--- a/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
+++ b/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
@@ -29,11 +29,6 @@ public class AppIndexingPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
+++ b/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
@@ -32,7 +32,7 @@ public class AppIndexingPackage implements ReactPackage {
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
-    
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();


### PR DESCRIPTION
Add Support for React Native 0.47

Since of recently in master the unused createJSModules has been removed and ReactPackage's no longer contain the definition of createJSModules. There for it must be removed in order to not yield a compile error. This is breaking change.

facebook/react-native@ce6fb33