### PR TITLE
Remove overriden createJSModules RN 0.47

### DIFF
--- a/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
+++ b/android/src/main/java/com/igalarzab/reactnative/appindexing/AppIndexingPackage.java
@@ -28,7 +28,7 @@ public class AppIndexingPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Add Support for React Native 0.47

Since of recently in master the unused createJSModules has been removed and ReactPackage's no longer contain the definition of createJSModules. There for it must be removed in order to not yield a compile error. This is breaking change.

facebook/react-native@ce6fb33